### PR TITLE
Add example pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.7.1",
     "siwe": "^1.1.6",
+    "use-debounce": "^9.0.3",
     "usehooks-ts": "^2.9.1",
     "wagmi": "^0.10.0"
   },

--- a/src/pages/examples/mint-nft.tsx
+++ b/src/pages/examples/mint-nft.tsx
@@ -1,0 +1,94 @@
+import { useAccount, useBalance, useContractWrite, usePrepareContractWrite, useWaitForTransaction, useNetwork } from 'wagmi'
+import { Button, Heading, Text, ListItem, UnorderedList } from '@chakra-ui/react'
+import { NextSeo } from 'next-seo'
+import { LinkComponent } from 'components/layout/LinkComponent'
+
+function MintNFT() {
+  const { chain } = useNetwork()
+
+  const prepareContractWrite = usePrepareContractWrite({
+    // WAGMI NFT Example contract
+    // https://opensea.io/collection/wagmi-mint-example
+    address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+    abi: [
+      {
+        name: 'mint',
+        type: 'function',
+        stateMutability: 'nonpayable',
+        inputs: [],
+        outputs: [],
+      },
+    ],
+    functionName: 'mint',
+  })
+  const contractWrite = useContractWrite(prepareContractWrite.config)
+  const waitForTransaction = useWaitForTransaction({ hash: contractWrite.data?.hash })
+
+  const handleSendTransation = () => {
+    contractWrite.write?.()
+  }
+
+  return (
+    <div>
+      <Heading as="h3" fontSize="xl" my={4}>
+        Try out
+      </Heading>
+      <Button
+        width="full"
+        disabled={waitForTransaction.isLoading || contractWrite.isLoading || !contractWrite.write}
+        mt={4}
+        onClick={handleSendTransation}>
+        {waitForTransaction.isLoading ? 'Minting NFT...' : contractWrite.isLoading ? 'Check your wallet' : 'Mint NFT'}
+      </Button>
+      {waitForTransaction.isSuccess && (
+        <div>
+          <Text mt={2} fontSize="lg">
+            Successfully Minted NFT!
+          </Text>
+          <Text fontSize="lg" fontWeight="bold">
+            <LinkComponent href={`${chain?.blockExplorers?.default.url}/tx/${contractWrite.data?.hash}`}>Check on block explorer</LinkComponent>
+          </Text>
+        </div>
+      )}
+      {waitForTransaction.isError && (
+        <div>
+          <Text mt={2} color="red" fontSize="lg">
+            Error minting NFT
+          </Text>
+          <Text color="red" fontSize="lg" fontWeight="bold">
+            {waitForTransaction.error?.message}
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function MintNFTExample() {
+  const { isConnected } = useAccount()
+
+  if (isConnected) {
+    return (
+      <div>
+        <NextSeo title="Mint NFT" />
+        <Heading as="h2" fontSize="2xl" my={4}>
+          Mint ERC721 NFT
+        </Heading>
+        <p>This example shows how to mint an ERC721 NFT.</p>
+
+        <UnorderedList>
+          <ListItem>
+            <LinkComponent href="https://docs.openzeppelin.com/contracts/3.x/erc721">ERC721</LinkComponent>
+          </ListItem>
+          <ListItem>
+            <LinkComponent href="https://wagmi.sh/examples/contract-write">Wagmi Docs</LinkComponent>
+          </ListItem>
+        </UnorderedList>
+
+        <MintNFT />
+      </div>
+    )
+  }
+
+  return <div>Connect your wallet first to sign a message.</div>
+}

--- a/src/pages/examples/passport.tsx
+++ b/src/pages/examples/passport.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { useAccount, useSigner } from 'wagmi'
 import { Button, Heading, Text } from '@chakra-ui/react'
 import { useState } from 'react'

--- a/src/pages/examples/send-erc20.tsx
+++ b/src/pages/examples/send-erc20.tsx
@@ -1,0 +1,109 @@
+import { useDebounce } from 'use-debounce'
+import { useAccount, useBalance, useContractWrite, usePrepareContractWrite, useWaitForTransaction, useNetwork, erc20ABI } from 'wagmi'
+import { Button, FormControl, FormLabel, Heading, Input, NumberInput, NumberInputField, Text } from '@chakra-ui/react'
+import { useState } from 'react'
+import { NextSeo } from 'next-seo'
+import { utils } from 'ethers'
+import { LinkComponent } from 'components/layout/LinkComponent'
+
+function SendERC20() {
+  const [tokenContract, setTokenContract] = useState('')
+  const [debouncedTokenContract] = useDebounce(tokenContract, 500)
+
+  const [to, setTo] = useState('')
+  const [debouncedTo] = useDebounce(to, 500)
+
+  const [amount, setAmount] = useState<string>()
+  const [debouncedAmount] = useDebounce(amount, 500)
+
+  const { chain } = useNetwork()
+  const { address } = useAccount()
+  const balance = useBalance({
+    address,
+    token: debouncedTokenContract as `0x{string}`,
+  })
+
+  const prepareContractWrite = usePrepareContractWrite({
+    address: debouncedTokenContract,
+    abi: erc20ABI,
+    functionName: 'transfer',
+    args: [(debouncedTo as `0x{string}`) ?? '0x0', debouncedAmount ? utils.parseEther(debouncedAmount) : utils.parseEther('0')],
+  })
+  const contractWrite = useContractWrite(prepareContractWrite.config)
+  const waitForTransaction = useWaitForTransaction({ hash: contractWrite.data?.hash, onSettled: () => balance.refetch() })
+
+  const handleSendTransation = () => {
+    contractWrite.write?.()
+  }
+
+  return (
+    <div>
+      <Heading as="h3" fontSize="xl" my={4}>
+        Send ERC20
+      </Heading>
+
+      <FormControl>
+        <FormLabel>Token Contract</FormLabel>
+        <Input value={tokenContract} onChange={(e) => setTokenContract(e.target.value)} placeholder="0xA0Cf…251e" />
+
+        <FormLabel mt={2}>Recipient</FormLabel>
+        <Input value={to} onChange={(e) => setTo(e.target.value)} placeholder="0xA0Cf…251e" />
+
+        <FormLabel mt={2}>Amount</FormLabel>
+        <NumberInput value={amount} onChange={(value) => setAmount(value)} mb={2}>
+          <NumberInputField placeholder="0.05" />
+        </NumberInput>
+        <Text>
+          Your balance: {balance.data?.formatted} {balance.data?.symbol}
+        </Text>
+
+        <Button
+          disabled={waitForTransaction.isLoading || contractWrite.isLoading || !contractWrite.write || !to || !amount}
+          mt={4}
+          onClick={handleSendTransation}>
+          {waitForTransaction.isLoading ? 'Sending...' : contractWrite.isLoading ? 'Check your wallet' : 'Send'}
+        </Button>
+        {waitForTransaction.isSuccess && (
+          <div>
+            <Text mt={2} fontSize="lg">
+              Successfully sent {amount} {balance.data?.symbol} to {to}
+            </Text>
+            <Text fontSize="lg" fontWeight="bold">
+              <LinkComponent href={`${chain?.blockExplorers?.default.url}/tx/${contractWrite.data?.hash}`}>Check on block explorer</LinkComponent>
+            </Text>
+          </div>
+        )}
+        {waitForTransaction.isError && (
+          <div>
+            <Text mt={2} color="red" fontSize="lg">
+              Error sending {amount} {balance.data?.symbol} to {to}
+            </Text>
+            <Text color="red" fontSize="lg" fontWeight="bold">
+              {waitForTransaction.error?.message}
+            </Text>
+          </div>
+        )}
+      </FormControl>
+    </div>
+  )
+}
+
+export default function SendERC20Example() {
+  const { isConnected } = useAccount()
+
+  if (isConnected) {
+    return (
+      <div>
+        <NextSeo title="Send ERC20 transaction" />
+        <Heading as="h2" fontSize="2xl" my={4}>
+          Send ERC20 transaction
+        </Heading>
+        <p>This example shows how to send an ERC20 transaction. You can use this to send any ERC20 to another address.</p>
+
+        <SendERC20 />
+      </div>
+    )
+  }
+
+  return <div>Connect your wallet first to sign a message.</div>
+}

--- a/src/pages/examples/send-ether.tsx
+++ b/src/pages/examples/send-ether.tsx
@@ -1,0 +1,105 @@
+import { useDebounce } from 'use-debounce'
+import { useAccount, useBalance, usePrepareSendTransaction, useSendTransaction, useWaitForTransaction, useNetwork } from 'wagmi'
+import { Button, FormControl, FormLabel, Heading, Input, NumberInput, NumberInputField, Text } from '@chakra-ui/react'
+import { useState } from 'react'
+import { NextSeo } from 'next-seo'
+import { utils } from 'ethers'
+import { LinkComponent } from 'components/layout/LinkComponent'
+
+function SendEther() {
+  const [to, setTo] = useState('')
+  const [debouncedTo] = useDebounce(to, 500)
+
+  const [amount, setAmount] = useState('')
+  const [debouncedAmount] = useDebounce(amount, 500)
+
+  const { chain } = useNetwork()
+  const { address } = useAccount()
+  const balance = useBalance({
+    address,
+  })
+
+  const prepareSendTransaction = usePrepareSendTransaction({
+    request: {
+      to: debouncedTo,
+      value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
+    },
+  })
+  const sendTransaction = useSendTransaction(prepareSendTransaction.config)
+  const waitForTransaction = useWaitForTransaction({ hash: sendTransaction.data?.hash })
+
+  const handleSendTransation = () => {
+    sendTransaction.sendTransaction?.()
+  }
+
+  return (
+    <div>
+      <Heading as="h3" fontSize="xl" my={4}>
+        Send Ether
+      </Heading>
+
+      <FormControl>
+        <FormLabel>Recipient</FormLabel>
+        <Input value={to} onChange={(e) => setTo(e.target.value)} placeholder="0xA0Cf…251e" />
+
+        <FormLabel mt={2}>Amount</FormLabel>
+        <NumberInput mb={2} value={amount} onChange={(value) => setAmount(value)}>
+          <NumberInputField placeholder="0.05" />
+        </NumberInput>
+        <Text>
+          Your balance: {balance.data?.formatted} {balance.data?.symbol}
+        </Text>
+
+        <Button
+          disabled={waitForTransaction.isLoading || sendTransaction.isLoading || !sendTransaction.sendTransaction || !to || !amount}
+          mt={4}
+          onClick={handleSendTransation}>
+          {waitForTransaction.isLoading ? 'Sending...' : sendTransaction.isLoading ? 'Check your wallet' : 'Send'}
+        </Button>
+        {waitForTransaction.isSuccess && (
+          <div>
+            <Text mt={2} fontSize="lg">
+              Successfully sent {amount} ether to {to}
+            </Text>
+            <Text fontSize="lg" fontWeight="bold">
+              <LinkComponent href={`${chain?.blockExplorers?.default.url}/tx/${sendTransaction.data?.hash}`}>Check on block explorer</LinkComponent>
+            </Text>
+          </div>
+        )}
+        {waitForTransaction.isError && (
+          <div>
+            <Text mt={2} color="red" fontSize="lg">
+              Error sending {amount} ether to {to}
+            </Text>
+            <Text color="red" fontSize="lg" fontWeight="bold">
+              {waitForTransaction.error?.message}
+            </Text>
+          </div>
+        )}
+      </FormControl>
+    </div>
+  )
+}
+
+export default function SendEtherExample() {
+  const { isConnected } = useAccount()
+
+  if (isConnected) {
+    return (
+      <div>
+        <NextSeo title="Send Ether transaction" />
+        <Heading as="h2" fontSize="2xl" my={4}>
+          Send Ether transaction
+        </Heading>
+        <p>
+          This example shows how to send an Ether transaction. You can use this to send Ether to another address, or to interact with a smart
+          contract.
+        </p>
+
+        <SendEther />
+      </div>
+    )
+  }
+
+  return <div>Connect your wallet first to sign a message.</div>
+}

--- a/src/pages/examples/send-ether.tsx
+++ b/src/pages/examples/send-ether.tsx
@@ -26,7 +26,7 @@ function SendEther() {
     },
   })
   const sendTransaction = useSendTransaction(prepareSendTransaction.config)
-  const waitForTransaction = useWaitForTransaction({ hash: sendTransaction.data?.hash })
+  const waitForTransaction = useWaitForTransaction({ hash: sendTransaction.data?.hash, onSettled: () => balance.refetch() })
 
   const handleSendTransation = () => {
     sendTransaction.sendTransaction?.()

--- a/src/pages/examples/sign.tsx
+++ b/src/pages/examples/sign.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { useAccount, useSignMessage } from 'wagmi'
 import { Button, FormControl, FormLabel, Heading, Textarea } from '@chakra-ui/react'
 import { useState } from 'react'

--- a/src/pages/examples/siwe.tsx
+++ b/src/pages/examples/siwe.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { useAccount, useNetwork, useSignMessage } from 'wagmi'
 import { SiweMessage } from 'siwe'
 import { useEffect, useState } from 'react'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,9 @@ export default function Home() {
           <ListItem>
             <LinkComponent href="/examples/send-ether">Send Ether transaction</LinkComponent>
           </ListItem>
+          <ListItem>
+            <LinkComponent href="/examples/send-erc20">Send ERC20 transaction</LinkComponent>
+          </ListItem>
         </UnorderedList>
       </main>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,6 +25,9 @@ export default function Home() {
           <ListItem>
             <LinkComponent href="/examples/send-erc20">Send ERC20 transaction</LinkComponent>
           </ListItem>
+          <ListItem>
+            <LinkComponent href="/examples/mint-nft">Mint NFT</LinkComponent>
+          </ListItem>
         </UnorderedList>
       </main>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,9 @@ export default function Home() {
           <ListItem>
             <LinkComponent href="/examples/passport">Gitcoin Passport</LinkComponent>
           </ListItem>
+          <ListItem>
+            <LinkComponent href="/examples/send-ether">Send Ether transaction</LinkComponent>
+          </ListItem>
         </UnorderedList>
       </main>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6486,6 +6486,11 @@ use-callback-ref@^1.3.0:
   dependencies:
     tslib "^2.0.0"
 
+use-debounce@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-9.0.3.tgz#bac660c19ab7b38662e08608fee23c7ad303f532"
+  integrity sha512-FhtlbDtDXILJV7Lix5OZj5yX/fW1tzq+VrvK1fnT2bUrPOGruU9Rw8NCEn+UI9wopfERBEZAOQ8lfeCJPllgnw==
+
 use-sidecar@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"


### PR DESCRIPTION
This PR, inspired by #4 removes the react imports in the example pages (since Next already does the react importing automatically) and adds the following example pages:
- [Send Ether transaction](https://nexth-7p4mr0wgw-marthendalnunes.vercel.app/examples/send-ether)
- [Send ERC20 transaction](https://nexth-7p4mr0wgw-marthendalnunes.vercel.app/examples/send-erc20)
- [Mint NFT](https://nexth-7p4mr0wgw-marthendalnunes.vercel.app/examples/mint-nft)