### PR TITLE
Add one click deploy to vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn dev
 
 ## Deploy on Vercel 🚢
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwslyvh%2Fnexth&env=DEPLOYER_KEY)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwslyvh%2Fnexth)
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=nexth&filter=next.js&utm_source=nexth&utm_campaign=nexth-readme) from the creators of Next.js.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ yarn dev
 
 ## Deploy on Vercel 🚢
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwslyvh%2Fnexth&env=DEPLOYER_KEY)
+
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=nexth&filter=next.js&utm_source=nexth&utm_campaign=nexth-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.


### PR DESCRIPTION
This PR introduces a One-Click Deploy to Vercel button to the README, making it easier for users to deploy the project to their Vercel account.