### PR TITLE
Add more Passport related hooks

### DIFF
--- a/src/components/layout/PassportScore.tsx
+++ b/src/components/layout/PassportScore.tsx
@@ -13,7 +13,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { FaRobot } from 'react-icons/fa'
-import { usePassportScore } from 'hooks/usePassportScore'
+import { usePassportScore } from 'hooks/passport/usePassportScore'
 import { LinkComponent } from './LinkComponent'
 
 interface Props {

--- a/src/hooks/passport/usePassportScore.tsx
+++ b/src/hooks/passport/usePassportScore.tsx
@@ -6,7 +6,7 @@ export function usePassportScore(round?: boolean) {
   const COMMUNITY_ID = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_COMMUNITY_ID
   const API_KEY = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_API_KEY
   if (!COMMUNITY_ID || !API_KEY) {
-    console.warn('Gitcoin passport Community ID or API Key not set')
+    console.warn('Gitcoin Passport Community ID or API Key not set')
   }
 
   const { address, isConnected } = useAccount()

--- a/src/hooks/passport/usePassportStamps.tsx
+++ b/src/hooks/passport/usePassportStamps.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react'
+import { State, PassportStamp } from 'types'
+import { useAccount } from 'wagmi'
+
+export function usePassportStamps(withMetadata: boolean = false) {
+  const API_KEY = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_API_KEY
+  if (!API_KEY) {
+    console.warn('Gitcoin Passport API Key not set')
+  }
+
+  const { address, isConnected } = useAccount()
+  const [state, setState] = useState<State<PassportStamp[]>>({
+    loading: true,
+    error: undefined,
+    data: undefined,
+  })
+
+  useEffect(() => {
+    const getStamps = async () => {
+      const response = await fetch(`https://api.scorer.gitcoin.co/registry/stamps/${address}?include_metadata=${withMetadata}`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': API_KEY ?? '',
+        },
+      })
+
+      const data = await response.json()
+
+      if (response.status === 200) {
+        // TODO: Check "next" property and paginate if necessary.
+        setState({
+          loading: false,
+          error: undefined,
+          data: data.items,
+        })
+        return
+      }
+
+      console.log('Unable to get passport stamps')
+      setState({
+        loading: false,
+        error: data.detail ?? 'Unable to get passport stamps',
+        data: undefined,
+      })
+    }
+
+    if (API_KEY && isConnected && address) {
+      getStamps()
+    }
+  }, [API_KEY, address, isConnected])
+
+  return state
+}

--- a/src/hooks/passport/usePassportStamps.tsx
+++ b/src/hooks/passport/usePassportStamps.tsx
@@ -26,6 +26,8 @@ export function usePassportStamps(withMetadata: boolean = false) {
 
       const data = await response.json()
 
+      console.log('data: ', data)
+
       if (response.status === 200) {
         // TODO: Check "next" property and paginate if necessary.
         setState({

--- a/src/hooks/passport/usePassportStamps.tsx
+++ b/src/hooks/passport/usePassportStamps.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { State, PassportStamp } from 'types'
 import { useAccount } from 'wagmi'
 
+//** Fetches all the stamps that are connected to the current account. */
 export function usePassportStamps(withMetadata: boolean = false) {
   const API_KEY = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_API_KEY
   if (!API_KEY) {
@@ -25,8 +26,6 @@ export function usePassportStamps(withMetadata: boolean = false) {
       })
 
       const data = await response.json()
-
-      console.log('data: ', data)
 
       if (response.status === 200) {
         // TODO: Check "next" property and paginate if necessary.

--- a/src/hooks/passport/usePassportStampsIndex.tsx
+++ b/src/hooks/passport/usePassportStampsIndex.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react'
+import { State } from 'types'
+
+//** Fetches all the stamps that are available on Passport */
+export function usePassportStampsIndex() {
+  const API_KEY = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_API_KEY
+  if (!API_KEY) {
+    console.warn('Gitcoin Passport API Key not set')
+  }
+
+  const [state, setState] = useState<State<any[]>>({
+    loading: true,
+    error: undefined,
+    data: undefined,
+  })
+
+  useEffect(() => {
+    const getStampsIndex = async () => {
+      const response = await fetch(`https://api.scorer.gitcoin.co/registry/stamp-metadata`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': API_KEY ?? '',
+        },
+      })
+
+      const data = await response.json()
+
+      if (response.status === 200) {
+        setState({
+          loading: false,
+          error: undefined,
+          data: data,
+        })
+        return
+      }
+
+      console.log('Unable to get passport stamps index')
+      setState({
+        loading: false,
+        error: data.detail ?? 'Unable to get passport stamps index',
+        data: undefined,
+      })
+    }
+
+    if (API_KEY) {
+      getStampsIndex()
+    }
+  }, [API_KEY])
+
+  return state
+}

--- a/src/hooks/passport/usePassportSubmit.tsx
+++ b/src/hooks/passport/usePassportSubmit.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { useAccount, useWalletClient } from 'wagmi'
+
+export function usePassportSubmit() {
+  const COMMUNITY_ID = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_COMMUNITY_ID
+  const API_KEY = process.env.NEXT_PUBLIC_GITCOIN_PASSPORT_API_KEY
+  if (!COMMUNITY_ID || !API_KEY) {
+    console.warn('Gitcoin Passport Community ID or API Key not set')
+  }
+
+  const { data: signer } = useWalletClient()
+  const { address, isConnected } = useAccount()
+  const [submitting, setSubmitting] = useState<boolean>(false)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  const headers = API_KEY
+    ? {
+        'Content-Type': 'application/json',
+        'X-API-Key': API_KEY,
+      }
+    : undefined
+
+  async function submit(withSigningMessage?: boolean) {
+    if (!signer || !isConnected) return
+    setSubmitting(true)
+
+    try {
+      const body: {
+        address: string | undefined
+        community: string | undefined
+        signature?: string | undefined
+        nonce?: string | undefined
+      } = {
+        address,
+        community: COMMUNITY_ID,
+      }
+
+      if (withSigningMessage) {
+        // Get nonce from Gitcoin
+        const signResponse = await fetch(`https://api.scorer.gitcoin.co/registry/signing-message`, {
+          headers,
+        })
+        const { message, nonce } = await signResponse.json()
+
+        // Sign message
+        let signature: string
+        try {
+          signature = await signer.signMessage({
+            message: message,
+          })
+          body.signature = signature
+          body.nonce = nonce
+        } catch (e) {
+          setError('Unable to sign message')
+          return
+        }
+      }
+
+      // Submit Passport to Gitcoin
+      const response = await fetch(`https://api.scorer.gitcoin.co/registry/submit-passport`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+
+      if (response.status !== 200) {
+        setError('Unable to submit passport')
+        return
+      }
+    } catch (e) {
+      console.error('failed to submit passport for scoring: ', e)
+      setError('Unable to submit passport')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return { submit, submitting, error }
+}

--- a/src/pages/examples/passport.tsx
+++ b/src/pages/examples/passport.tsx
@@ -57,7 +57,7 @@ export default function PassportExample() {
           <div>
             <HeadingComponent as="h3">Passport Stamps</HeadingComponent>
             {stamps.map((stamp) => (
-              <div>
+              <div key={stamp.credential.proof.jws}>
                 <div>Provider: {stamp.credential.credentialSubject.provider}</div>
                 <div>IssuanceDate: {stamp.credential.issuanceDate}</div>
                 <div>ExpirationDate: {stamp.credential.expirationDate}</div>

--- a/src/pages/examples/passport.tsx
+++ b/src/pages/examples/passport.tsx
@@ -1,18 +1,19 @@
 import { useAccount } from 'wagmi'
-import { Button, Text } from '@chakra-ui/react'
-import { useState } from 'react'
+import { Button, Text, Card, CardBody, SimpleGrid, Image } from '@chakra-ui/react'
 import { NextSeo } from 'next-seo'
 import { LinkComponent } from 'components/layout/LinkComponent'
 import { usePassportScore } from 'hooks/passport/usePassportScore'
 import { usePassportSubmit } from 'hooks/passport/usePassportSubmit'
 import { usePassportStamps } from 'hooks/passport/usePassportStamps'
+import { usePassportStampsIndex } from 'hooks/passport/usePassportStampsIndex'
 import { HeadingComponent } from 'components/layout/HeadingComponent'
 
 export default function PassportExample() {
   const { address, isConnected } = useAccount()
   const { loading, data: score, error } = usePassportScore()
   const { submit, submitting, error: submitError } = usePassportSubmit()
-  const { loading: loadingStamps, data: stamps, error: stampsError } = usePassportStamps()
+  const { loading: loadingStamps, data: stamps, error: stampsError } = usePassportStamps(true)
+  const { data: availableStamps } = usePassportStampsIndex()
 
   if (isConnected) {
     return (
@@ -54,15 +55,45 @@ export default function PassportExample() {
         )}
 
         {!loadingStamps && !!stamps && stamps.length > 0 && (
-          <div>
-            <HeadingComponent as="h3">Passport Stamps</HeadingComponent>
+          <div style={{ marginTop: '30px' }}>
+            <HeadingComponent as="h3">Your Passport Stamps</HeadingComponent>
             {stamps.map((stamp) => (
-              <div key={stamp.credential.proof.jws}>
-                <div>Provider: {stamp.credential.credentialSubject.provider}</div>
-                <div>IssuanceDate: {stamp.credential.issuanceDate}</div>
-                <div>ExpirationDate: {stamp.credential.expirationDate}</div>
-              </div>
+              <Card key={stamp.credential.proof.jws} maxW="sm">
+                <CardBody>
+                  <Image src={stamp.metadata?.platform.icon} boxSize="50px" />
+                  <Text style={{ marginTop: '30px' }} fontSize="md">
+                    {stamp.credential.credentialSubject.provider}
+                  </Text>
+                  <Text style={{ marginTop: '5px' }} fontSize="sm">
+                    IssuanceDate: {new Date(stamp.credential.issuanceDate).toLocaleString()}
+                  </Text>
+                  <Text style={{ marginTop: '5px' }} fontSize="sm">
+                    ExpirationDate: {new Date(stamp.credential.expirationDate).toLocaleString()}
+                  </Text>
+                </CardBody>
+              </Card>
             ))}
+          </div>
+        )}
+
+        {!!availableStamps && availableStamps.length > 0 && (
+          <div style={{ marginTop: '30px' }}>
+            <HeadingComponent as="h3">Available Passport Stamps</HeadingComponent>
+            <SimpleGrid columns={3} spacing={5}>
+              {availableStamps.map((stamp) => (
+                <Card key={stamp.id} maxW="sm">
+                  <CardBody>
+                    <Image src={stamp.icon} boxSize="50px" />
+                    <Text style={{ marginTop: '30px' }} fontSize="md">
+                      {stamp.name}
+                    </Text>
+                    <Text style={{ marginTop: '10px' }} fontSize="sm">
+                      {stamp.description}
+                    </Text>
+                  </CardBody>
+                </Card>
+              ))}
+            </SimpleGrid>
           </div>
         )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,32 @@ export interface State<T> {
   data?: T
   error?: string
 }
+
+export interface PassportStamp {
+  version: string
+  credential: {
+    type: string[]
+    proof: {
+      jws: string
+      type: string
+      created: string
+      proofPurpose: string
+      verificationMethod: string
+    }
+    issuer: string
+    '@context': string[]
+    issuanceDate: string
+    expirationDate: string
+    credentialSubject: {
+      id: string
+      hash: string
+      '@context': [
+        {
+          hash: string
+          provider: string
+        }
+      ]
+      provider: string
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,4 +31,17 @@ export interface PassportStamp {
       provider: string
     }
   }
+  metadata?: {
+    description: string
+    group: string
+    hash: string
+    name: string
+    platform: {
+      id: string
+      icon: string
+      name: string
+      description: string
+      connectMessage: string
+    }
+  }
 }


### PR DESCRIPTION
Added hooks:

- `usePassportSubmit` easily submit a Passport for scoring
- `usePassportStamps` fetch the stamps associated with a specific Passport
- `usePassportStampsIndex` fetch a list of stamps that can be connected to Passports

Updated Passport example page to use new hooks. Page now shows the stamps of the connected address and a list of all the passport stamps.

![Screenshot 2023-06-25 at 8 33 24 AM](https://github.com/wslyvh/nexth/assets/95650694/c561ff78-e01d-40f7-a9ca-fb29828f4b81)
