### PR TITLE
Updated Twitter to X logo

### DIFF
--- a/packages/app/src/components/Footer.tsx
+++ b/packages/app/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SITE_DESCRIPTION, SOCIAL_GITHUB, SOCIAL_TWITTER } from '@/utils/site'
-import { FaGithub, FaTwitter } from 'react-icons/fa6'
+import { FaGithub, FaXTwitter } from 'react-icons/fa6'
 import { NetworkStatus } from './NetworkStatus'
 import { LinkComponent } from './LinkComponent'
 
@@ -18,7 +18,7 @@ export function Footer() {
             <FaGithub />
           </LinkComponent>
           <LinkComponent href={`https://twitter.com/${SOCIAL_TWITTER}`}>
-            <FaTwitter />
+            <FaXTwitter />
           </LinkComponent>
         </div>
       </footer>


### PR DESCRIPTION
- Not sure if Twitter Bird logo is being used for historical purpose, but updated code to display X instead of the Twitter Bird logo.
- Didn't update Twitter URL since if it is x.com it changes to twitter.com, so doesn't matter right now the URL. 