### PR TITLE
Add TokenBalance component

### DIFF
--- a/packages/app/src/app/examples/send-ether/page.tsx
+++ b/packages/app/src/app/examples/send-ether/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/context/Toaster'
 import Ethereum from '@/assets/icons/ethereum.png'
 import { TokenBalance } from '@/components/TokenBalance'
 import { TokenQuantityInput } from '@/components/TokenQuantityInput'
+import { formatBalance } from '@/utils/formatBalance'
 
 type Address = `0x${string}` | undefined
 

--- a/packages/app/src/app/examples/send-ether/page.tsx
+++ b/packages/app/src/app/examples/send-ether/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { useAccount, useBalance, useEstimateGas, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi'
 import { useState, useEffect } from 'react'
-import { parseEther, formatEther, isAddress } from 'viem'
+import { parseEther, isAddress } from 'viem'
 import { useToast } from '@/context/Toaster'
 import Ethereum from '@/assets/icons/ethereum.png'
+import { TokenBalance } from '@/components/TokenBalance'
 
 type Address = `0x${string}` | undefined
 
@@ -67,10 +68,6 @@ export default function SendEther() {
     }
   }, [txSuccess, txError])
 
-  const formatBalance = (balance: bigint) => {
-    return parseFloat(formatEther(balance, 'wei')).toFixed(4)
-  }
-
   return (
     <div className='flex-column align-center '>
       <h1 className='text-xl'>Send Ether</h1>
@@ -109,12 +106,7 @@ export default function SendEther() {
                 <img width={50} className='opacity-50 ml-10' src={Ethereum.src} alt='ethereum' />
               </div>
               <div className='stat-title '>Your balance</div>
-
-              {balance.data ? (
-                <div className='stat-value text-lg w-[150px]'>{formatBalance(balance.data!.value)}</div>
-              ) : (
-                <p>Please connect your wallet</p>
-              )}
+              {address ? <TokenBalance address={address} /> : <p>Please connect your wallet</p>}
             </div>
           </div>
           <button

--- a/packages/app/src/app/examples/send-token/page.tsx
+++ b/packages/app/src/app/examples/send-token/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 import { useAccount, useBalance, useSimulateContract, useWriteContract, useWaitForTransactionReceipt } from 'wagmi'
-import { erc20Abi, formatEther, isAddress } from 'viem'
+import { erc20Abi, isAddress } from 'viem'
 import { useState, useEffect } from 'react'
 import { parseEther } from 'viem'
 import { useToast } from '@/context/Toaster'
 import Token from '@/assets/icons/token.png'
+import { TokenBalance } from '@/components/TokenBalance'
 
 type Address = `0x${string}` | undefined
 
@@ -79,10 +80,6 @@ export default function SendToken() {
     }
   }, [txSuccess, txError])
 
-  const formatBalance = (balance: bigint) => {
-    return parseFloat(formatEther(balance, 'wei')).toFixed(4)
-  }
-
   return (
     <div className='flex-column align-center '>
       <h1 className='text-xl'>Send ERC-20 Token</h1>
@@ -136,9 +133,8 @@ export default function SendToken() {
                   <img className='opacity-25 ml-10' width={50} src={Token.src} alt='token' />
                 </div>
                 <div className='stat-title '>Your balance</div>
-
-                {balanceData ? (
-                  <div className='stat-value text-lg w-[150px]'>{formatBalance(balanceData.value)}</div>
+                {tokenAddress && address ? (
+                  <TokenBalance address={address} tokenAddress={tokenAddress} />
                 ) : (
                   <p>Please connect your wallet</p>
                 )}

--- a/packages/app/src/app/examples/send-token/page.tsx
+++ b/packages/app/src/app/examples/send-token/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/context/Toaster'
 import Token from '@/assets/icons/token.png'
 import { TokenBalance } from '@/components/TokenBalance'
 import { TokenQuantityInput } from '@/components/TokenQuantityInput'
+import { formatBalance } from '@/utils/formatBalance'
 
 type Address = `0x${string}` | undefined
 

--- a/packages/app/src/components/TokenBalance.tsx
+++ b/packages/app/src/components/TokenBalance.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { useBalance, useReadContract } from 'wagmi'
+import { formatEther } from 'viem'
+import { toBigInt } from 'ethers'
+
+const abi = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+interface TokenBalanceProps {
+  readonly address: `0x${string}`
+  readonly tokenAddress?: `0x${string}`
+  readonly className?: string
+  readonly toFixed?: number
+}
+
+export const TokenBalance = ({ address, tokenAddress, toFixed, className }: TokenBalanceProps) => {
+  const ETHBalance = useBalance({ address })
+  const tokenBalance = useReadContract({
+    abi,
+    address: tokenAddress,
+    functionName: 'balanceOf',
+    args: [address],
+  })
+
+  const formatBalance = (balance: bigint) => {
+    if (!balance) return null
+    return parseFloat(formatEther(balance, 'wei')).toFixed(toFixed ?? 4)
+  }
+  if (!ETHBalance.data && !tokenBalance.data) return null
+  if (tokenAddress) {
+    return (
+      <div className={`stat-value text-lg w-[150px] ${className}`}>
+        {tokenBalance.data ? formatBalance(tokenBalance.data) : 0}
+      </div>
+    )
+  }
+  return (
+    <div className={`stat-value text-lg w-[150px] ${className}`}>
+      {formatBalance(ETHBalance.data?.value ?? toBigInt(0))}
+    </div>
+  )
+}

--- a/packages/app/src/components/TokenBalance.tsx
+++ b/packages/app/src/components/TokenBalance.tsx
@@ -43,7 +43,7 @@ export const TokenBalance = ({ address, tokenAddress, toFixed, onBalanceChange, 
   })
 
   useEffect(() => {
-    // pass the vaule of the balance to the parent component
+    // pass the value of the balance to the parent component on change
     if (tokenBalance.data && onBalanceChange) {
       onBalanceChange({ balance: tokenBalance.data, formattedBalance: formatBalance(tokenBalance.data, toFixed) })
       return

--- a/packages/app/src/components/TokenBalance.tsx
+++ b/packages/app/src/components/TokenBalance.tsx
@@ -1,42 +1,23 @@
 'use client'
 import { useBalance, useReadContract } from 'wagmi'
-import { formatEther } from 'viem'
 import { toBigInt } from 'ethers'
 import { useEffect } from 'react'
-
-const abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    stateMutability: 'view',
-    inputs: [{ name: 'account', type: 'address' }],
-    outputs: [{ type: 'uint256' }],
-  },
-] as const
+import { formatBalance } from '@/utils/formatBalance'
+import { erc20Abi } from 'viem'
 
 interface TokenBalanceProps {
   readonly address: `0x${string}`
   readonly tokenAddress?: `0x${string}`
   readonly className?: string
   readonly toFixed?: number
-  readonly onBalanceChange?: ({
-    balance,
-    formattedBalance,
-  }: {
-    balance: bigint
-    formattedBalance: string | null
-  }) => void
-}
-
-const formatBalance = (balance: bigint, toFixed?: number) => {
-  if (!balance) return null
-  return parseFloat(formatEther(balance, 'wei')).toFixed(toFixed ?? 4)
+  readonly onBalanceChange?: ({ balance, formattedBalance }: { balance: bigint; formattedBalance?: string }) => void
 }
 
 export const TokenBalance = ({ address, tokenAddress, toFixed, onBalanceChange, className }: TokenBalanceProps) => {
   const ETHBalance = useBalance({ address })
+
   const tokenBalance = useReadContract({
-    abi,
+    abi: erc20Abi,
     address: tokenAddress,
     functionName: 'balanceOf',
     args: [address],

--- a/packages/app/src/utils/formatBalance.tsx
+++ b/packages/app/src/utils/formatBalance.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { formatEther } from 'viem'
+
+export const formatBalance = (balance: bigint, toFixed?: number) => {
+  if (!balance) return undefined
+  return parseFloat(formatEther(balance, 'wei')).toFixed(toFixed ?? 4)
+}


### PR DESCRIPTION
This pull request adds a reusable TokenBalance component that can be used to display the balance of a token or Ether for a given address. The component uses the `useBalance` and `useReadContract` hooks from the `wagmi` library to fetch the balance data. It also includes the necessary imports and type definitions.