### PR TITLE
Fix input validation in TokenQuantityInput component

### DIFF
--- a/packages/app/src/components/TokenQuantityInput.tsx
+++ b/packages/app/src/components/TokenQuantityInput.tsx
@@ -20,6 +20,10 @@ export function TokenQuantityInput({
   const smallestStep = parseFloat(amount) < 1 ? 1 / Math.pow(10, maxValue?.split('.')[1].length ?? 1) : 1
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // only allow numbers and one decimal point
+    if (!/^\d*\.?\d*$/.test(e.target.value)) {
+      return
+    }
     setAmount(e.target.value)
     onChange(e.target.value)
   }


### PR DESCRIPTION
This pull request fixes the input validation in the TokenQuantityInput component to prevent a UI error. The handleChange function now checks if the input value contains only numbers and one decimal point before updating the state.


Error without the validation 👇 
<img width="1028" alt="Screenshot 2024-04-25 at 12 10 17 PM" src="https://github.com/wslyvh/nexth/assets/24376928/e33ae474-c004-436a-9f4f-b53c322db750">
