### PR TITLE
Rewarding 2024 contributors

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -45,7 +45,7 @@
       "login": "stevennevins",
       "score": 43,
       "percentage": 2.68,
-      "address": ""
+      "address": "0x46207Fc64A4a4dE2Bfce15a1F1D2Eb5db14bF1E9"
     },
     {
       "login": "Rask467",
@@ -57,7 +57,7 @@
       "login": "carlosrsabreu",
       "score": 23,
       "percentage": 1.43,
-      "address": ""
+      "address": "0xAB093EBbB9D97b1d571E9dB56209A43846775C75"
     },
     {
       "login": "fosgate29",
@@ -69,7 +69,7 @@
       "login": "unholypanda",
       "score": 20,
       "percentage": 1.24,
-      "address": ""
+      "address": "0xa380339B85F7f4BA5d5640Bcf2c75FdcB4d4CDFa"
     }
   ]
 }

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -1,0 +1,75 @@
+{
+  "metadata": {
+    "repository": "wslyvh/nexth",
+    "runDate": "2024-12-16",
+    "sinceDate": null
+  },
+  "contributors": [
+    {
+      "login": "wslyvh",
+      "score": 695,
+      "percentage": 43.25,
+      "address": "0x8289432acd5eb0214b1c2526a5edb480aa06a9ab"
+    },
+    {
+      "login": "hone1er",
+      "score": 281,
+      "percentage": 17.49,
+      "address": "0xB73AB607bA73B5649405344e3f4F6c4feDc665cD"
+    },
+    {
+      "login": "Maxtho8",
+      "score": 137,
+      "percentage": 8.53,
+      "address": ""
+    },
+    {
+      "login": "jpgonzalezra",
+      "score": 135,
+      "percentage": 8.4,
+      "address": "0xE96c033444B4f72501EE0a3eb07B1887a9C8Fdcf"
+    },
+    {
+      "login": "Envoy-VC",
+      "score": 118,
+      "percentage": 7.34,
+      "address": "0xc0d86456F6f2930b892f3DAD007CDBE32c081FE6"
+    },
+    {
+      "login": "marthendalnunes",
+      "score": 102,
+      "percentage": 6.35,
+      "address": "0xED83f43e646313B3828a552cb31E3990d3dc9753"
+    },
+    {
+      "login": "stevennevins",
+      "score": 43,
+      "percentage": 2.68,
+      "address": ""
+    },
+    {
+      "login": "Rask467",
+      "score": 33,
+      "percentage": 2.05,
+      "address": ""
+    },
+    {
+      "login": "carlosrsabreu",
+      "score": 23,
+      "percentage": 1.43,
+      "address": ""
+    },
+    {
+      "login": "fosgate29",
+      "score": 20,
+      "percentage": 1.24,
+      "address": ""
+    },
+    {
+      "login": "unholypanda",
+      "score": 20,
+      "percentage": 1.24,
+      "address": ""
+    }
+  ]
+}

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -45,7 +45,7 @@
       "login": "stevennevins",
       "score": 43,
       "percentage": 2.68,
-      "address": "0x46207Fc64A4a4dE2Bfce15a1F1D2Eb5db14bF1E9"
+      "address": "0xB090A53d9851AcB7E6a55fb9AFE3975901152233"
     },
     {
       "login": "Rask467",
@@ -63,7 +63,7 @@
       "login": "fosgate29",
       "score": 20,
       "percentage": 1.24,
-      "address": ""
+      "address": "0x67726e491bcC86d109FD5D67dBE81fd6F6Da6A24"
     },
     {
       "login": "unholypanda",

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The score is calculated using [Contributor Graph](https://github.com/wslyvh/cont
 ### Distribution
 
 - In 2024 the project received $7,075 USD in funding. 60% ($4,245) is distributed to core contributors.
+  - https://arbiscan.io/tx/0x95d6cd302374d64a401e35a27570fec9793bd9751cbfdeec36d3ade3b1965c24
 
 ## Deploy on Vercel 🚢
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ npm run dev
 yarn dev
 ```
 
+## Funding
+
+This project is funding its core dependencies with [Drips protocol](https://www.drips.network/app/projects/github/wslyvh/nexth?exact). A split contract that splits 60% of all proceeds with core contributors and 40% for dependencies.
+
+### Contributors
+
+Contributors to this repository are rewarded based on their contributions to the project. Their contribution score is calculated based on a combination of the commits, issues, pull requests, and other contributions that determine the amount of funding they receives.
+
+The score is calculated using [Contributor Graph](https://github.com/wslyvh/contributor-graph).
+
+### Distribution
+
+- In 2024 the project received $7,075 USD in funding. 60% ($4,245) is distributed to core contributors.
+
 ## Deploy on Vercel 🚢
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwslyvh%2Fnexth)


### PR DESCRIPTION
I'm exploring new ways to funds open-source software and its contributors. All proceeds from 2024 were previously deposited into Drips protocol already https://www.drips.network/app/projects/github/wslyvh/nexth?exact

60% of all proceeds are allocated for contributors/maintainers (myself included) and 40% for dependencies (managed on Drips)

This PR is to track the 60% of the received funds with a total of $4,245 USD over 2024.
The contribution graph is generated using a simple scoring mechanism https://github.com/wslyvh/contributor-graph
(open to ideas on how to improve!)

Which leads to the percentages for each contributor as documented in contributors.json

I already added some of your addresses, but please confirm or share your Ethereum address for distribution of funds.

Thanks for your support and contributions! @hone1er @Maxtho8 @jpgonzalezra @Envoy-VC @marthendalnunes @stevennevins @Rask467 @carlosrsabreu @fosgate29 @unholypanda 🙏