### PR TITLE
Improve ENS support ahead of ENSv2 launch

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
     "react-icons": "^4.11.0",
     "react-toastify": "^10.0.5",
     "siwe": "^3.0.0",
-    "viem": "^2.35.0",
+    "viem": "^2.41.2",
     "wagmi": "^2.14.16"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
     "react-icons": "^4.11.0",
     "react-toastify": "^10.0.5",
     "siwe": "^3.0.0",
-    "viem": "^2.27.2",
+    "viem": "^2.35.0",
     "wagmi": "^2.14.16"
   },
   "devDependencies": {

--- a/packages/app/src/app/hooks/useEnsProfile.ts
+++ b/packages/app/src/app/hooks/useEnsProfile.ts
@@ -1,13 +1,6 @@
 import { useCallback } from 'react'
-import { normalize } from 'viem/ens'
+import { normalize, toCoinType } from 'viem/ens'
 import { useEnsAddress, useEnsAvatar, useEnsText } from 'wagmi'
-
-// Convert an EVM chainId to its ENS coin type (EIP-2304).
-// ETH mainnet is the special-case coin type 60; all other EVM chains use 0x80000000 | chainId.
-function evmChainIdToCoinType(chainId: number): number {
-  if (chainId === 1) return 60
-  return (0x80000000 | chainId) >>> 0
-}
 
 const useEnsProfile = ({ ensName, key, chainId }: { ensName: string; key?: string; chainId?: number }) => {
   const normalizedName = useCallback(() => {
@@ -21,7 +14,7 @@ const useEnsProfile = ({ ensName, key, chainId }: { ensName: string; key?: strin
   }, [ensName])
 
   const name = normalizedName()
-  const coinType = chainId !== undefined ? evmChainIdToCoinType(chainId) : undefined
+  const coinType = chainId !== undefined ? toCoinType(chainId) : undefined
 
   const { data: ensAddress } = useEnsAddress({ name, chainId: 1, coinType })
   const { data: ensAvatar } = useEnsAvatar({ name, chainId: 1 })

--- a/packages/app/src/app/hooks/useEnsProfile.ts
+++ b/packages/app/src/app/hooks/useEnsProfile.ts
@@ -2,18 +2,28 @@ import { useCallback } from 'react'
 import { normalize } from 'viem/ens'
 import { useEnsAddress, useEnsAvatar, useEnsText } from 'wagmi'
 
-const useEnsProfile = ({ ensName, key }: { ensName: string; key?: string }) => {
+// Convert an EVM chainId to its ENS coin type (EIP-2304).
+// ETH mainnet is the special-case coin type 60; all other EVM chains use 0x80000000 | chainId.
+function evmChainIdToCoinType(chainId: number): number {
+  if (chainId === 1) return 60
+  return (0x80000000 | chainId) >>> 0
+}
+
+const useEnsProfile = ({ ensName, key, chainId }: { ensName: string; key?: string; chainId?: number }) => {
   const normalizedName = useCallback(() => {
+    // Only attempt resolution for inputs that look like a name (contain a dot).
+    if (!ensName.includes('.') || ensName.length <= 2) return ''
     try {
       return normalize(ensName)
-    } finally {
+    } catch {
       return ''
     }
   }, [ensName])
 
   const name = normalizedName()
+  const coinType = chainId !== undefined ? evmChainIdToCoinType(chainId) : undefined
 
-  const { data: ensAddress } = useEnsAddress({ name, chainId: 1 })
+  const { data: ensAddress } = useEnsAddress({ name, chainId: 1, coinType })
   const { data: ensAvatar } = useEnsAvatar({ name, chainId: 1 })
   const { data: ensTextData } = useEnsText({ name, chainId: 1, key: key ?? 'text' })
 

--- a/packages/app/src/components/AddressInput.tsx
+++ b/packages/app/src/components/AddressInput.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { isAddress } from 'viem'
 import Image from 'next/image'
 import { useAccount } from 'wagmi'
@@ -15,8 +15,14 @@ interface AddressInputProps extends React.HTMLProps<HTMLInputElement> {
 export const AddressInput = ({ onRecipientChange, onRawInputChange, disabled = false }: AddressInputProps) => {
   const [isValidToAddress, setIsValidToAddress] = useState<boolean>(false)
   const [rawTokenAddress, setRawTokenAddress] = useState<string>('')
+  const [debouncedInput, setDebouncedInput] = useState<string>('')
   const { chain } = useAccount()
-  const { ensAddress: ensAddy, ensAvatar } = useEnsProfile({ ensName: rawTokenAddress, chainId: chain?.id })
+  const { ensAddress: ensAddy, ensAvatar } = useEnsProfile({ ensName: debouncedInput, chainId: chain?.id })
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedInput(rawTokenAddress), 300)
+    return () => clearTimeout(timer)
+  }, [rawTokenAddress])
 
   // Handle input change for recipient address
   const handleToAdressInput = (_to: string) => {

--- a/packages/app/src/components/AddressInput.tsx
+++ b/packages/app/src/components/AddressInput.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { isAddress } from 'viem'
 import Image from 'next/image'
+import { useAccount } from 'wagmi'
 import useEnsProfile from '@/app/hooks/useEnsProfile'
 import { truncateAddress } from '../utils/helpers/formatTools'
 
@@ -14,7 +15,8 @@ interface AddressInputProps extends React.HTMLProps<HTMLInputElement> {
 export const AddressInput = ({ onRecipientChange, onRawInputChange, disabled = false }: AddressInputProps) => {
   const [isValidToAddress, setIsValidToAddress] = useState<boolean>(false)
   const [rawTokenAddress, setRawTokenAddress] = useState<string>('')
-  const { ensAddress: ensAddy, ensAvatar } = useEnsProfile({ ensName: rawTokenAddress })
+  const { chain } = useAccount()
+  const { ensAddress: ensAddy, ensAvatar } = useEnsProfile({ ensName: rawTokenAddress, chainId: chain?.id })
 
   // Handle input change for recipient address
   const handleToAdressInput = (_to: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,7 +7838,7 @@ viem@2.23.2:
     ox "0.6.7"
     ws "8.18.0"
 
-viem@2.x, viem@>=2.29.0, viem@>=2.37.9, viem@^2.1.1, viem@^2.21.26, viem@^2.27.2, viem@^2.31.7:
+viem@2.x, viem@>=2.29.0, viem@>=2.37.9, viem@^2.1.1, viem@^2.21.26, viem@^2.31.7, viem@^2.35.0:
   version "2.41.2"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.41.2.tgz#117eab182b6b5501e47462269bb63f8b365a802e"
   integrity sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,7 +7838,7 @@ viem@2.23.2:
     ox "0.6.7"
     ws "8.18.0"
 
-viem@2.x, viem@>=2.29.0, viem@>=2.37.9, viem@^2.1.1, viem@^2.21.26, viem@^2.31.7, viem@^2.35.0:
+viem@2.x, viem@>=2.29.0, viem@>=2.37.9, viem@^2.1.1, viem@^2.21.26, viem@^2.31.7, viem@^2.41.2:
   version "2.41.2"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.41.2.tgz#117eab182b6b5501e47462269bb63f8b365a802e"
   integrity sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g==


### PR DESCRIPTION
## Summary

- Bump `viem` minimum version to `^2.35.0` (required for ENSv2 Universal Resolver support — resolution still starts on Ethereum Mainnet but now works with the new resolver contract)
- Fix a `try/finally` bug in `useEnsProfile` where `finally { return '' }` was always overriding the `try` return value, silently breaking **all** ENS resolution
- Add dot-notation guard in `useEnsProfile` so resolution is only attempted on name-like inputs (`input.includes('.') && input.length > 2`) — this correctly handles `.eth`, DNS imports, subdomains, and emoji domains per the ENSv2 readiness guide
- Pass the connected chain's ID from `AddressInput` to `useEnsProfile` and derive the [ENSIP-11](https://docs.ens.domains/ensip/11) `coinType`, so `useEnsAddress` returns the chain-specific address record on L2s (e.g. Base, Optimism, Arbitrum)

## References

- ENSv2 Readiness Guide: https://docs.ens.domains/web/ensv2-readiness/

## Test plan

- [x] Resolve `ur.integration-tests.eth` — should return `0x2222222222222222222222222222222222222222`
- [x] Resolve `test.offchaindemo.eth` (CCIP-read) — should return `0x779981590E7Ccc0CFAe8040Ce7151324747cDb97`
- [x] Type a `.eth` name in the `AddressInput` and confirm ENS resolution works
- [x] Connect on a supported L2 (e.g. Base) and verify the resolved address uses the correct coin type record

## Preview

Deployed the changes to https://nexth-app-tau.vercel.app/examples/send-ether